### PR TITLE
[AN-321]: RegexFilter for startswith not startWith

### DIFF
--- a/src/druidry/data_source.py
+++ b/src/druidry/data_source.py
@@ -30,7 +30,7 @@ DataSourceView
     queries.
 """
 from . import aggregations
-from .filters import Filter, AndFilter, BoundFilter, ColumnComparisonFilter, LikeFilter, OrFilter, SelectorFilter, NotFilter
+from .filters import Filter, AndFilter, BoundFilter, ColumnComparisonFilter, LikeFilter, OrFilter, RegexFilter, SelectorFilter, NotFilter
 from .intervals import Interval
 from .queries import GroupByQuery, TimeseriesQuery
 from .results import QueryResult
@@ -311,6 +311,13 @@ def like_filter(f):
     return LikeFilter(
         dimension=f['left']['field'], pattern=pattern)
 
+def regex_filter(f):
+    if f['left']['type'] != 'field' or f['right']['type'] != 'value':
+        raise ValueError('Druid does not support dynamic patterns.')
+    affix_start = f['type'] == 'startswith'
+    pattern = "|".join([('^{}.*' if affix_start else '.*{}$').format(value) for value in f['right']['value']])
+    return RegexFilter(
+        dimension=f['left']['field'], pattern=pattern)
 
 def combine_filter(f):
     filters = [translate_filter(sf) for sf in f['filters'] if translate_filter(sf)]
@@ -338,8 +345,8 @@ FILTER_TYPES = {
     '<=': inequality_filter,
     'in': contains_filter,
     'not in': contains_filter,
-    'endwith': like_filter,
-    'startswith': like_filter,
+    'endwith': regex_filter,
+    'startswith': regex_filter,
     'and': combine_filter,
     'or': combine_filter,
     'not': negate_filter

--- a/src/druidry/data_source.py
+++ b/src/druidry/data_source.py
@@ -311,7 +311,7 @@ def like_filter(f):
     return LikeFilter(
         dimension=f['left']['field'], pattern=pattern)
 
-def regex_filter(f):
+def regex_like_filter(f):
     if f['left']['type'] != 'field' or f['right']['type'] != 'value':
         raise ValueError('Druid does not support dynamic patterns.')
     affix_start = f['type'] == 'startswith'
@@ -345,8 +345,8 @@ FILTER_TYPES = {
     '<=': inequality_filter,
     'in': contains_filter,
     'not in': contains_filter,
-    'endwith': regex_filter,
-    'startswith': regex_filter,
+    'endwith': regex_like_filter,
+    'startswith': regex_like_filter,
     'and': combine_filter,
     'or': combine_filter,
     'not': negate_filter

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -534,3 +534,29 @@ class TestFilters(unittest.TestCase):
                           }
 
         self.assertEqual(druidry.data_source.translate_filter(input_filter), expected_value)
+
+    def test_startswith_value_filter(self):
+        input_filter = {
+            "type": "startswith",
+            "right": {"type": "value", "value": ["Chrom","Fire"]},
+            "left": {"type": "field", "field": "browser"}
+        }
+        expected_filter = {
+            "type": "regex",
+            "dimension": "browser",
+            "pattern": "^Chrom.*|^Fire.*"
+        }
+        self.assertEqual(druidry.data_source.translate_filter(input_filter), expected_filter)
+
+    def test_endwith_value_filter(self):
+        input_filter = {
+            "type": "endwith",
+            "right": {"type": "value", "value": ["Chrom","Fire"]},
+            "left": {"type": "field", "field": "browser"}
+        }
+        expected_filter = {
+            "type": "regex",
+            "dimension": "browser",
+            "pattern": ".*Chrom$|.*Fire$"
+        }
+        self.assertEqual(druidry.data_source.translate_filter(input_filter), expected_filter)


### PR DESCRIPTION
# Why
https://monetate.atlassian.net/browse/AN-321

Use `RegexFilter` for `startswith` and `not startWith` instead of `LikeFilter` in druidry

## Demo

### Design Mocks

### Before
N/A
### After
<img width="719" alt="Screen Shot 2019-08-07 at 11 58 30 AM" src="https://user-images.githubusercontent.com/51330277/62640116-d7a36080-b90e-11e9-9be2-28acb26b1216.png">

<img width="1440" alt="Screen Shot 2019-08-07 at 4 17 02 PM" src="https://user-images.githubusercontent.com/51330277/62654992-0f220500-b92f-11e9-9d00-b2661c0d63bc.png">

<img width="1414" alt="Screen Shot 2019-08-07 at 4 18 31 PM" src="https://user-images.githubusercontent.com/51330277/62655003-12b58c00-b92f-11e9-98b7-be3d18d3b834.png">

Without split
<img width="1108" alt="Screen Shot 2019-08-08 at 9 22 24 AM" src="https://user-images.githubusercontent.com/51330277/62706711-16dcba80-b9be-11e9-912b-131bf7e7c095.png">
