### PR TITLE
install code in editable for jenkins builds so we don't create a cached wheel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
                 sh "${VENV} ${WORKSPACE}/venv"
                 withEnv(["PATH=${env.WORKSPACE}/venv/bin:${env.PATH}"]) {
                     githubNotify context:'Python Requirements', description:'Installing python requirements',  status: 'PENDING'
-                    sh "pip install .[results,doc,test]"
+                    sh "pip install -e .[results,doc,test]" // install editable so it doesn't build a cached wheel
                 }
             }
             post {


### PR DESCRIPTION
cached wheel can cause issues/conflicts for other processes on the box and/or get uploaded to artifactory