### PR TITLE
Upgrade pandas version to 0.23 for compatibility with python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         'results': [
-            'pandas>=0.12.0,<0.21'  # our code breaks somewhere above 0.20, tests catch the errors
+            'pandas>=0.12.0,<0.24'  # our code breaks somewhere above 0.24, tests catch the errors
         ],
         'doc': [
             "Sphinx==1.4",


### PR DESCRIPTION
### What 

Upgrade pandas version to 0.23.4 

### Why

Installing pandas version <0.23 fails on python 3.7
Tests fail on pandas version >=0.24.0