### PR TITLE
Abort superseded Jenkins PR builds on new push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,13 @@ VENV = 'virtualenv'
 import org.monetate.Slack
 def slack = new Slack(steps, REPO_NAME)
 
+// Abort superseded builds on non-mainline branches; mainline (master/main/patch-*) builds every commit.
+if (!isMainlineBranch()) {
+    properties([
+        disableConcurrentBuilds(abortPrevious: true),
+    ])
+}
+
 pipeline {
     agent { label "node-v8" }
     environment {


### PR DESCRIPTION
## Summary

Adds a `properties()` call gated on `!isMainlineBranch()` that sets `disableConcurrentBuilds(abortPrevious: true)` for non-mainline builds, so that when a new commit is pushed to a pull request or feature branch, Jenkins aborts the in-flight build for the previous commit instead of letting both run to completion.

## Motivation

When commits land on a branch or PR in quick succession, builds for stale commits keep running and tie up executors even though their results no longer matter. With this option, only the newest commit's build runs, freeing agents sooner and shortening queue times.

## Notes

- `isMainlineBranch()` (monetate-jenkins-pipeline shared library) is true on `master`, `main`, and `patch-*`. Those mainline branches never have the property applied and keep building every commit unconditionally -- never aborted or serialized.
- `isMainlineBranch()` is null-safe: it returns false when `BRANCH_NAME` is unset, and these pipelines run as multibranch jobs where `BRANCH_NAME` is always set.
- Where the Jenkinsfile also configures `buildDiscarder` (declarative `options` block), the gated `properties()` call restates it: `properties()` replaces the job properties it manages, so restating the retention setting ensures non-mainline jobs keep it regardless of plugin version behavior. The two declarations are kept in sync by a comment at each site.
- Requires the Pipeline: Job plugin >= 2.42. The option takes effect starting with the first build that runs this Jenkinsfile.

## Testing

Jenkinsfile-only change. Behavior can be confirmed after merge by pushing two commits to a branch/PR in quick succession and observing the first build abort, and verifying master/patch-* builds run to completion as before.
