### PR TITLE
Cap build retention with branch-conditional properties()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,15 @@ import org.monetate.Slack
 def slack = new Slack(steps, REPO_NAME)
 
 // Abort superseded builds on non-mainline branches; mainline (master/main/patch-*) builds every commit.
-if (!isMainlineBranch()) {
+// Both day and count caps are required -- a day-only rotator keeps every build a busy
+// job produces inside the window, which is unbounded disk on the controller.
+if (isMainlineBranch()) {
     properties([
+        buildDiscarder(logRotator(daysToKeepStr: '60', numToKeepStr: '100')),
+    ])
+} else {
+    properties([
+        buildDiscarder(logRotator(daysToKeepStr: '30', numToKeepStr: '5')),
         disableConcurrentBuilds(abortPrevious: true),
     ])
 }


### PR DESCRIPTION
## Summary
Add a branch-conditional `buildDiscarder` so builds stop being retained forever. Mainline keeps 60 days/100 builds; PR and topic branches keep 30 days/5.

## Background
The 2026-08-09 dev-build-cm disk-full outage was caused by unbounded Jenkins build retention: the controller's 250G `/var/lib/jenkins` volume hit 99% and the built-in node went offline, blocking all builds and the multibranch scans that prune closed-PR jobs. A fleet audit after the incident found this repo's Jenkinsfile sets no `buildDiscarder` at all, so its jobs retain every build indefinitely. The volume here is far lower than the repos that actually filled the disk, so this is preventive rather than urgent — but it is the same unbounded shape, and the existing top-level `properties()` call makes the fix a small one.

## What changed
- The top-level branch-conditional `properties()` call now owns build retention for every branch: mainline gets `logRotator(daysToKeepStr: '60', numToKeepStr: '100')`, PR/topic branches get `logRotator(daysToKeepStr: '30', numToKeepStr: '5')` alongside the existing `disableConcurrentBuilds(abortPrevious: true)`.
- Both day and count caps are set deliberately: a day-only rotator keeps every build produced inside the window, which is what left the controller unbounded.

## Verification
- The identical pattern built green on monetate-server ([branch build](https://dev-build-cm.monetate.org/job/monetate/job/monetate-server/job/jjpersch%2Fjenkins-build-retention/1/) and PR-30702 build 2, both SUCCESS), and the resulting job config was verified via the Jenkins API to carry the properties()-set rotator values.
- Left to CI: this PR's own build exercises the edited Jenkinsfile end to end.

## Deployment plan and risks
Merging is the deployment; jobs pick the new retention up on their next run. No declarative `options{}` block in this repo owns a discarder, so `properties()` is the sole owner and there is no transitional run without one. Build history beyond the caps is permanently discarded on the next run's post-build cleanup; if older build logs from this repo are still wanted, export them before merging.
